### PR TITLE
Update LEIN_VERSION and LEIN_URL

### DIFF
--- a/freedom/overtone/vendor/lein/lein
+++ b/freedom/overtone/vendor/lein/lein
@@ -4,7 +4,7 @@
 # somewhere on your $PATH, like ~/bin. The rest of Leiningen will be
 # installed upon first run into the ~/.lein/self-installs directory.
 
-export LEIN_VERSION="2.3.4"
+export LEIN_VERSION="2.5.1"
 
 case $LEIN_VERSION in
     *SNAPSHOT) SNAPSHOT="YES" ;;
@@ -65,7 +65,7 @@ function self_install {
   fi
   echo "Downloading Leiningen to $LEIN_JAR now..."
   mkdir -p "$(dirname "$LEIN_JAR")"
-  LEIN_URL="https://leiningen.s3.amazonaws.com/downloads/leiningen-$LEIN_VERSION-standalone.jar"
+  LEIN_URL="https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip"
   $HTTP_CLIENT "$LEIN_JAR.pending" "$LEIN_URL"
   if [ $? == 0 ]; then
       # TODO: checksum


### PR DESCRIPTION
Updated to reflect latest version as previous LEIN_URL did not connect.
The latest version number and URL come from the current Leningen install script:
https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein

The `make` command now completes.
